### PR TITLE
ContentTypes

### DIFF
--- a/packages/kiota_abstractions/lib/src/serialization/parse_node_factory_registry.dart
+++ b/packages/kiota_abstractions/lib/src/serialization/parse_node_factory_registry.dart
@@ -35,14 +35,14 @@ class ParseNodeFactoryRegistry implements ParseNodeFactory {
         contentType.split(';').where((element) => element.isNotEmpty).first;
     if (contentTypeAssociatedFactories.containsKey(vendorSpecificContentType)) {
       return contentTypeAssociatedFactories[vendorSpecificContentType]!
-          .getRootParseNode(contentType, content);
+          .getRootParseNode(vendorSpecificContentType, content);
     }
 
     final cleanedContentType =
         vendorSpecificContentType.replaceAll(contentTypeVendorCleanupRegex, '');
     if (contentTypeAssociatedFactories.containsKey(cleanedContentType)) {
       return contentTypeAssociatedFactories[cleanedContentType]!
-          .getRootParseNode(contentType, content);
+          .getRootParseNode(cleanedContentType, content);
     }
 
     throw UnsupportedError(

--- a/packages/kiota_abstractions/lib/src/serialization/serialization_writer_factory_registry.dart
+++ b/packages/kiota_abstractions/lib/src/serialization/serialization_writer_factory_registry.dart
@@ -29,14 +29,14 @@ class SerializationWriterFactoryRegistry implements SerializationWriterFactory {
         contentType.split(';').where((element) => element.isNotEmpty).first;
     if (contentTypeAssociatedFactories.containsKey(vendorSpecificContentType)) {
       return contentTypeAssociatedFactories[vendorSpecificContentType]!
-          .getSerializationWriter(contentType);
+          .getSerializationWriter(vendorSpecificContentType);
     }
 
     final cleanedContentType =
         vendorSpecificContentType.replaceAll(contentTypeVendorCleanupRegex, '');
     if (contentTypeAssociatedFactories.containsKey(cleanedContentType)) {
       return contentTypeAssociatedFactories[cleanedContentType]!
-          .getSerializationWriter(contentType);
+          .getSerializationWriter(cleanedContentType);
     }
 
     throw UnsupportedError(

--- a/packages/kiota_abstractions/test/serialization/parse_node_factory_registry_test.dart
+++ b/packages/kiota_abstractions/test/serialization/parse_node_factory_registry_test.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+
+import 'package:kiota_abstractions/kiota_abstractions.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'parse_node_factory_registry_test.mocks.dart';
+
+@GenerateMocks([ParseNodeFactory, ParseNode])
+void main() {
+  group('ParseNodeFactoryRegistry', () {
+    test('VendorSpecificContentType', () {
+      const contentType = 'application/json';
+      final mockFactory = MockParseNodeFactory();
+      final jsonStream= utf8.encode('{"test": "input"}');
+      final mockParseNode = MockParseNode();
+      when(mockFactory.getRootParseNode(contentType, jsonStream)).thenReturn(mockParseNode);
+      ParseNodeFactoryRegistry.defaultInstance.contentTypeAssociatedFactories.putIfAbsent(contentType, ()=>mockFactory);
+      final rootParseNode = ParseNodeFactoryRegistry.defaultInstance.getRootParseNode('application/vnd+json', jsonStream);
+      expect(rootParseNode, isNotNull);
+    });
+  });
+}

--- a/packages/kiota_abstractions/test/serialization/serialization_writer_factory_registry_test.dart
+++ b/packages/kiota_abstractions/test/serialization/serialization_writer_factory_registry_test.dart
@@ -1,0 +1,20 @@
+import 'package:kiota_abstractions/kiota_abstractions.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'serialization_writer_factory_registry_test.mocks.dart';
+
+@GenerateMocks([SerializationWriter, SerializationWriterFactory])
+void main() {
+  group('SerializationWriterFactoryRegistry', () {
+    test('VendorSpecificContentType', () {
+      const contentType = 'application/text';
+      final mockWriter = MockSerializationWriter();
+      final mockFactory = MockSerializationWriterFactory();
+      when(mockFactory.getSerializationWriter(contentType)).thenReturn(mockWriter);
+      SerializationWriterFactoryRegistry.defaultInstance.contentTypeAssociatedFactories.putIfAbsent(contentType, () => mockFactory);
+      final serializationWriter = SerializationWriterFactoryRegistry.defaultInstance.getSerializationWriter('application/vnd+text');
+      expect(serializationWriter, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Gets correct parsers/writers from factory when using a vendorspecific contenttype.