### PR TITLE
Configurationtypes

### DIFF
--- a/packages/kiota_abstractions/lib/kiota_abstractions.dart
+++ b/packages/kiota_abstractions/lib/kiota_abstractions.dart
@@ -15,6 +15,7 @@ import 'package:meta/meta.dart';
 import 'package:std_uritemplate/std_uritemplate.dart';
 import 'package:uuid/uuid.dart';
 
+part 'src/abstract_query_parameters.dart';
 part 'src/api_client_builder.dart';
 part 'src/api_exception.dart';
 part 'src/authentication/access_token_provider.dart';
@@ -27,6 +28,7 @@ part 'src/authentication/base_bearer_token_authentication_provider.dart';
 part 'src/base_request_builder.dart';
 part 'src/case_insensitive_map.dart';
 part 'src/date_only.dart';
+part 'src/default_query_parameters.dart';
 part 'src/error_mappings.dart';
 part 'src/extensions/base_request_builder_extensions.dart';
 part 'src/extensions/date_only_extensions.dart';

--- a/packages/kiota_abstractions/lib/src/abstract_query_parameters.dart
+++ b/packages/kiota_abstractions/lib/src/abstract_query_parameters.dart
@@ -1,6 +1,7 @@
 part of '../kiota_abstractions.dart';
 
 /// Type definition for query parameters.
-abstract class AbstractQueryParameters{
-  Map<String, dynamic> getQueryParameters();
+abstract class AbstractQueryParameters {
+  ///Return a map representation of the query parameters for the request
+  Map<String, dynamic> toMap();
 }

--- a/packages/kiota_abstractions/lib/src/abstract_query_parameters.dart
+++ b/packages/kiota_abstractions/lib/src/abstract_query_parameters.dart
@@ -1,0 +1,6 @@
+part of '../kiota_abstractions.dart';
+
+/// Type definition for query parameters.
+abstract class AbstractQueryParameters{
+  Map<String, dynamic> getQueryParameters();
+}

--- a/packages/kiota_abstractions/lib/src/default_query_parameters.dart
+++ b/packages/kiota_abstractions/lib/src/default_query_parameters.dart
@@ -1,11 +1,11 @@
 part of '../kiota_abstractions.dart';
 
 /// Type definition for query parameters.
-class DefaultQueryParameters extends AbstractQueryParameters{
+class DefaultQueryParameters extends AbstractQueryParameters {
   Map<String, dynamic> queryParameters = {};
 
   @override
-  Map<String, dynamic> getQueryParameters(){
+  Map<String, dynamic> toMap() {
     return queryParameters;
   }
 }

--- a/packages/kiota_abstractions/lib/src/default_query_parameters.dart
+++ b/packages/kiota_abstractions/lib/src/default_query_parameters.dart
@@ -1,0 +1,11 @@
+part of '../kiota_abstractions.dart';
+
+/// Type definition for query parameters.
+class DefaultQueryParameters extends AbstractQueryParameters{
+  Map<String, dynamic> queryParameters = {};
+
+  @override
+  Map<String, dynamic> getQueryParameters(){
+    return queryParameters;
+  }
+}

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -137,15 +137,14 @@ extension RequestInformationExtensions on RequestInformation {
     content = writer.getSerializedContent();
   }
 
-  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator, T Function() createParameters) {
-    if (configurator == null) {
+  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator, T Function()? createParameters) {
+    if (configurator == null || createParameters == null) {
       return;
     }
 
-    final config = RequestConfiguration<T>()
-    ..queryParameters = createParameters();
+    final config = RequestConfiguration<T>(queryParameters: createParameters());
     configurator(config);
-    
+
     addQueryParameters(config.queryParameters.getQueryParameters());
     addHeaders(config.headers);
     addRequestOptions(config.options);

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -137,15 +137,18 @@ extension RequestInformationExtensions on RequestInformation {
     content = writer.getSerializedContent();
   }
 
-  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator, T Function()? createParameters) {
+  void configure<T extends AbstractQueryParameters>(
+      void Function(RequestConfiguration<T>)? configurator,
+      T Function()? createParameters) {
     if (configurator == null || createParameters == null) {
       return;
     }
 
-    final config = RequestConfiguration<T>(HttpHeaders(), [], createParameters());
+    final config =
+        RequestConfiguration<T>(HttpHeaders(), [], createParameters());
     configurator(config);
 
-    addQueryParameters(config.queryParameters.getQueryParameters());
+    addQueryParameters(config.queryParameters.toMap());
     addHeaders(config.headers);
     addRequestOptions(config.options);
   }

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -137,7 +137,7 @@ extension RequestInformationExtensions on RequestInformation {
     content = writer.getSerializedContent();
   }
 
-  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator) {
+  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator, T Function() createParameters, void Function(T) parameterValues) {
     if (configurator == null) {
       return;
     }
@@ -145,8 +145,9 @@ extension RequestInformationExtensions on RequestInformation {
     final config = RequestConfiguration<T>();
 
     configurator(config);
-
-    addQueryParameters(config.queryParameters.getQueryParameters());
+    final typedParameters = createParameters();
+    parameterValues(typedParameters);
+    addQueryParameters(typedParameters.getQueryParameters());
     addHeaders(config.headers);
     addRequestOptions(config.options);
   }

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -137,17 +137,16 @@ extension RequestInformationExtensions on RequestInformation {
     content = writer.getSerializedContent();
   }
 
-  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator, T Function() createParameters, void Function(T) parameterValues) {
+  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator, T Function() createParameters) {
     if (configurator == null) {
       return;
     }
 
-    final config = RequestConfiguration<T>();
-
+    final config = RequestConfiguration<T>()
+    ..queryParameters = createParameters();
     configurator(config);
-    final typedParameters = createParameters();
-    parameterValues(typedParameters);
-    addQueryParameters(typedParameters.getQueryParameters());
+    
+    addQueryParameters(config.queryParameters.getQueryParameters());
     addHeaders(config.headers);
     addRequestOptions(config.options);
   }

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -142,7 +142,7 @@ extension RequestInformationExtensions on RequestInformation {
       return;
     }
 
-    final config = RequestConfiguration<T>(HttpHeaders(), [], queryParameters: createParameters());
+    final config = RequestConfiguration<T>(HttpHeaders(), [], createParameters());
     configurator(config);
 
     addQueryParameters(config.queryParameters.getQueryParameters());

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -137,16 +137,16 @@ extension RequestInformationExtensions on RequestInformation {
     content = writer.getSerializedContent();
   }
 
-  void configure<T>(void Function(RequestConfiguration)? configurator) {
+  void configure<T extends AbstractQueryParameters>(void Function(RequestConfiguration<T>)? configurator) {
     if (configurator == null) {
       return;
     }
 
-    final config = RequestConfiguration();
+    final config = RequestConfiguration<T>();
 
     configurator(config);
 
-    addQueryParameters(config.queryParameters);
+    addQueryParameters(config.queryParameters.getQueryParameters());
     addHeaders(config.headers);
     addRequestOptions(config.options);
   }

--- a/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
+++ b/packages/kiota_abstractions/lib/src/extensions/request_information_extensions.dart
@@ -142,7 +142,7 @@ extension RequestInformationExtensions on RequestInformation {
       return;
     }
 
-    final config = RequestConfiguration<T>(queryParameters: createParameters());
+    final config = RequestConfiguration<T>(HttpHeaders(), [], queryParameters: createParameters());
     configurator(config);
 
     addQueryParameters(config.queryParameters.getQueryParameters());

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -3,12 +3,12 @@ part of '../kiota_abstractions.dart';
 /// Request configuration type for [BaseRequestBuilder]s.
 class RequestConfiguration<T extends AbstractQueryParameters> {
 
-  RequestConfiguration({required this.queryParameters});
+  const RequestConfiguration(this.headers, this.options, {required this.queryParameters});
   /// The HTTP headers of the request.
-  HttpHeaders headers = HttpHeaders();
+  final HttpHeaders headers;
 
   /// The request options.
-  List<RequestOption> options = [];
+  final List<RequestOption> options;
 
-  T queryParameters;
+  final T queryParameters;
 }

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -7,4 +7,6 @@ class RequestConfiguration<T extends AbstractQueryParameters> {
 
   /// The request options.
   List<RequestOption> options = [];
+
+  late T queryParameters;
 }

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -2,8 +2,8 @@ part of '../kiota_abstractions.dart';
 
 /// Request configuration type for [BaseRequestBuilder]s.
 class RequestConfiguration<T extends AbstractQueryParameters> {
-
   const RequestConfiguration(this.headers, this.options, this.queryParameters);
+
   /// The HTTP headers of the request.
   final HttpHeaders headers;
 

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -7,7 +7,4 @@ class RequestConfiguration<T extends AbstractQueryParameters> {
 
   /// The request options.
   List<RequestOption> options = [];
-
-  /// The request query parameters.
- late T queryParameters;
 }

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -2,11 +2,13 @@ part of '../kiota_abstractions.dart';
 
 /// Request configuration type for [BaseRequestBuilder]s.
 class RequestConfiguration<T extends AbstractQueryParameters> {
+
+  RequestConfiguration({required this.queryParameters});
   /// The HTTP headers of the request.
   HttpHeaders headers = HttpHeaders();
 
   /// The request options.
   List<RequestOption> options = [];
 
-  late T queryParameters;
+  T queryParameters;
 }

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -1,7 +1,7 @@
 part of '../kiota_abstractions.dart';
 
 /// Request configuration type for [BaseRequestBuilder]s.
-class RequestConfiguration {
+class RequestConfiguration<T extends AbstractQueryParameters> {
   /// The HTTP headers of the request.
   HttpHeaders headers = HttpHeaders();
 
@@ -9,5 +9,5 @@ class RequestConfiguration {
   List<RequestOption> options = [];
 
   /// The request query parameters.
-  Map<String, dynamic> queryParameters = {};
+ late T queryParameters;
 }

--- a/packages/kiota_abstractions/lib/src/request_configuration.dart
+++ b/packages/kiota_abstractions/lib/src/request_configuration.dart
@@ -3,7 +3,7 @@ part of '../kiota_abstractions.dart';
 /// Request configuration type for [BaseRequestBuilder]s.
 class RequestConfiguration<T extends AbstractQueryParameters> {
 
-  const RequestConfiguration(this.headers, this.options, {required this.queryParameters});
+  const RequestConfiguration(this.headers, this.options, this.queryParameters);
   /// The HTTP headers of the request.
   final HttpHeaders headers;
 


### PR DESCRIPTION
Kiota generates a type for each operation with the query parameters for that operation. We want to limit the query parameters that we can use to those of the type belonging to the operation, to support this generics were added to the requestconfiguration class.