### PR TITLE
Allow lower version of http_parser

### DIFF
--- a/packages/kiota_http/pubspec.yaml
+++ b/packages/kiota_http/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   kiota_abstractions:
     path: ../kiota_abstractions
   http: ^1.2.2
-  http_parser: ^4.1.0
+  http_parser: ^4.0.2
   uuid: ^4.4.2
 
 dev_dependencies:


### PR DESCRIPTION
Apparently, the latest stable version of flutter only works with http_parser 4.0.2 because of their collection version 1.18.0.