### PR TITLE
Remove version generation and user agent middleware

### DIFF
--- a/packages/kiota_http/README.md
+++ b/packages/kiota_http/README.md
@@ -19,12 +19,3 @@ Install the package in the generated project:
 ```bash
 dart pub add kiota_http
 ```
-
-## Development
-
-To build the package, you first need to run `build_runner`.
-It generates the necessary files for the package to work and for running the tests:
-
-```bash
-dart run build_runner build -d
-```

--- a/packages/kiota_http/build.yaml
+++ b/packages/kiota_http/build.yaml
@@ -1,6 +1,0 @@
-targets:
-  $default:
-    builders:
-      build_version:
-        options:
-          output: lib/gen/version.dart

--- a/packages/kiota_http/lib/kiota_http.dart
+++ b/packages/kiota_http/lib/kiota_http.dart
@@ -7,7 +7,6 @@ import 'dart:typed_data';
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart' as retry;
 import 'package:kiota_abstractions/kiota_abstractions.dart';
-import 'package:kiota_http/gen/version.dart';
 import 'package:uuid/uuid.dart';
 
 part 'src/http_client_request_adapter.dart';

--- a/packages/kiota_http/lib/src/kiota_client_factory.dart
+++ b/packages/kiota_http/lib/src/kiota_client_factory.dart
@@ -4,23 +4,20 @@ class KiotaClientFactory {
   KiotaClientFactory._();
 
   static http.Client createClient() {
-    return UserAgentClient(
-      retry.RetryClient(
-        http.Client(),
-        when: (response) {
-          const retryCodes = {
-            408, // Request Timeout
-            429, // Too Many Requests
-            500, // Internal Server Error
-            502, // Bad Gateway
-            503, // Service Unavailable
-            504, // Gateway Timeout
-          };
+    return retry.RetryClient(
+      http.Client(),
+      when: (response) {
+        const retryCodes = {
+          408, // Request Timeout
+          429, // Too Many Requests
+          500, // Internal Server Error
+          502, // Bad Gateway
+          503, // Service Unavailable
+          504, // Gateway Timeout
+        };
 
-          return retryCodes.contains(response.statusCode);
-        },
-      ),
-      userAgent: 'kiota_http/$packageVersion',
+        return retryCodes.contains(response.statusCode);
+      },
     );
   }
 }

--- a/packages/kiota_http/pubspec.yaml
+++ b/packages/kiota_http/pubspec.yaml
@@ -20,4 +20,3 @@ dev_dependencies:
   test: ^1.25.2
   mockito: ^5.4.4
   build_runner: ^2.4.9
-  build_version: ^2.1.1


### PR DESCRIPTION
For the meantime, we have decided to not include a User-Agent header by default. Users can add it themselves, that is why the `UserAgentClient` is still in this package.

The reason why we don't include it is because it requires to run `build_runner` at development-time (and also build-time) which negatively impacts DX. As soon as we have a stable release workflow we will reconsider adding this again.