### PR TITLE
Make use of Dart workspaces

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -67,13 +67,6 @@ jobs:
         run: dart analyze --fatal-infos
         working-directory: packages/${{ matrix.package }}
 
-      - name: Run pana
-        if: always()
-        uses: axel-op/dart-package-analyzer@v3
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          relativePath: packages/${{ matrix.package }}
-
   test:
     runs-on: ubuntu-latest
     needs: define-matrix

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,49 @@
+pub-get:
+	dart pub get
+
 format:
 	dart format packages
 	dart format tooling
 
 generate: generate-abstractions generate-bundle generate-http generate-serialization-form generate-serialization-json generate-serialization-multipart
 
-generate-abstractions:
+generate-abstractions: pub-get
 	cd packages/microsoft_kiota_abstractions && dart run build_runner build --delete-conflicting-outputs
 
-generate-bundle:
+generate-bundle: pub-get
 	cd packages/microsoft_kiota_bundle && dart run build_runner build --delete-conflicting-outputs
 
-generate-http:
+generate-http: pub-get
 	cd packages/microsoft_kiota_http && dart run build_runner build --delete-conflicting-outputs
 
-generate-serialization-form:
+generate-serialization-form: pub-get
 	cd packages/microsoft_kiota_serialization_form && dart run build_runner build --delete-conflicting-outputs
 
-generate-serialization-json:
+generate-serialization-json: pub-get
 	cd packages/microsoft_kiota_serialization_json && dart run build_runner build --delete-conflicting-outputs
 
-generate-serialization-multipart:
+generate-serialization-multipart: pub-get
 	cd packages/microsoft_kiota_serialization_multipart && dart run build_runner build --delete-conflicting-outputs
 
 test: test-abstractions test-bundle test-http test-serialization-text test-serialization-form test-serialization-json test-serialization-multipart
 
-test-abstractions: pub-get-abstractions generate-abstractions
+test-abstractions: generate-abstractions
 	cd packages/microsoft_kiota_abstractions && dart test
 
-test-bundle: pub-get-bundle generate-bundle
+test-bundle: generate-bundle
 	cd packages/microsoft_kiota_bundle && dart test
 
-test-http: pub-get-http generate-http
+test-http: generate-http
 	cd packages/microsoft_kiota_http && dart test
 
-test-serialization-text: pub-get-serialization-text
+test-serialization-text:
 	cd packages/microsoft_kiota_serialization_text && dart test
 
-test-serialization-form: pub-get-serialization-form generate-serialization-form
+test-serialization-form: generate-serialization-form
 	cd packages/microsoft_kiota_serialization_form && dart test
 
-test-serialization-json: pub-get-serialization-json generate-serialization-json
+test-serialization-json: generate-serialization-json
 	cd packages/microsoft_kiota_serialization_json && dart test
 
-test-serialization-multipart: pub-get-serialization-multipart generate-serialization-multipart
+test-serialization-multipart: generate-serialization-multipart
 	cd packages/microsoft_kiota_serialization_multipart && dart test

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,6 @@
-pub-get: pub-get-abstractions pub-get-bundle pub-get-http pub-get-serialization-text pub-get-serialization-form pub-get-serialization-json pub-get-serialization-multipart
-
-pub-get-abstractions:
-	cd packages/microsoft_kiota_abstractions && dart pub get
-
-pub-get-bundle:
-	cd packages/microsoft_kiota_bundle && dart pub get
-
-pub-get-http:
-	cd packages/microsoft_kiota_http && dart pub get
-
-pub-get-serialization-text:
-	cd packages/microsoft_kiota_serialization_text && dart pub get
-
-pub-get-serialization-form:
-	cd packages/microsoft_kiota_serialization_form && dart pub get
-
-pub-get-serialization-json:
-	cd packages/microsoft_kiota_serialization_json && dart pub get
-
-pub-get-serialization-multipart:
-	cd packages/microsoft_kiota_serialization_multipart && dart pub get
-
 format:
 	dart format packages
+	dart format tooling
 
 generate: generate-abstractions generate-bundle generate-http generate-serialization-form generate-serialization-json generate-serialization-multipart
 

--- a/packages/microsoft_kiota_abstractions/lib/src/authentication/api_key_authentication_provider.dart
+++ b/packages/microsoft_kiota_abstractions/lib/src/authentication/api_key_authentication_provider.dart
@@ -56,10 +56,6 @@ class ApiKeyAuthenticationProvider implements AuthenticationProvider {
         request.uri = newUri;
       case ApiKeyLocation.header:
         request.headers.put(_parameterName, _apiKey);
-      default:
-        throw UnimplementedError(
-          'The API key location $_keyLocation is not implemented.',
-        );
     }
 
     return Future<void>.value();

--- a/packages/microsoft_kiota_abstractions/pubspec.yaml
+++ b/packages/microsoft_kiota_abstractions/pubspec.yaml
@@ -12,7 +12,9 @@ topics:
   - client
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   meta: ^1.16.0

--- a/packages/microsoft_kiota_abstractions/pubspec.yaml
+++ b/packages/microsoft_kiota_abstractions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_abstractions
 description: "Provides interfaces and base classes for Dart Kiota clients."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_abstractions
 repository: https://github.com/microsoft/dart_kiota
 

--- a/packages/microsoft_kiota_abstractions/pubspec.yaml
+++ b/packages/microsoft_kiota_abstractions/pubspec.yaml
@@ -22,6 +22,6 @@ dependencies:
 
 dev_dependencies:
   strict: ^2.1.0
-  test: ^1.25.12
-  mockito: ^5.4.4
+  test: ^1.25.14
+  mockito: ^5.4.5
   build_runner: any

--- a/packages/microsoft_kiota_abstractions/pubspec.yaml
+++ b/packages/microsoft_kiota_abstractions/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_abstractions
 description: "Provides interfaces and base classes for Dart Kiota clients."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_abstractions
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 topics:
   - kiota

--- a/packages/microsoft_kiota_bundle/pubspec.yaml
+++ b/packages/microsoft_kiota_bundle/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   strict: ^2.1.0
-  test: ^1.25.12
-  mockito: ^5.4.4
+  test: ^1.25.14
+  mockito: ^5.4.5
   build_runner: any
   http: ^1.2.2

--- a/packages/microsoft_kiota_bundle/pubspec.yaml
+++ b/packages/microsoft_kiota_bundle/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_bundle
 description: "Provides a bundle of all the default Kiota implementations for easy consumption."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_bundle
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/microsoft_kiota_bundle/pubspec.yaml
+++ b/packages/microsoft_kiota_bundle/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_bundle
 description: "Provides a bundle of all the default Kiota implementations for easy consumption."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_bundle
 repository: https://github.com/microsoft/dart_kiota
 
@@ -10,12 +10,12 @@ environment:
 resolution: workspace
 
 dependencies:
-  microsoft_kiota_abstractions: '>=0.0.1 <1.0.0'
-  microsoft_kiota_http: '>=0.0.1 <1.0.0'
-  microsoft_kiota_serialization_text: '>=0.0.1 <1.0.0'
-  microsoft_kiota_serialization_form: '>=0.0.1 <1.0.0'
-  microsoft_kiota_serialization_json: '>=0.0.1 <1.0.0'
-  microsoft_kiota_serialization_multipart: '>=0.0.1 <1.0.0'
+  microsoft_kiota_abstractions: ^0.0.1
+  microsoft_kiota_http: ^0.0.1
+  microsoft_kiota_serialization_text: ^0.0.1
+  microsoft_kiota_serialization_form: ^0.0.1
+  microsoft_kiota_serialization_json: ^0.0.1
+  microsoft_kiota_serialization_multipart: ^0.0.1
 
 dev_dependencies:
   strict: ^2.1.0

--- a/packages/microsoft_kiota_bundle/pubspec.yaml
+++ b/packages/microsoft_kiota_bundle/pubspec.yaml
@@ -5,7 +5,9 @@ repository: https://github.com/kiota-community/dart_kiota
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   microsoft_kiota_abstractions:

--- a/packages/microsoft_kiota_http/pubspec.yaml
+++ b/packages/microsoft_kiota_http/pubspec.yaml
@@ -17,6 +17,6 @@ dependencies:
 
 dev_dependencies:
   strict: ^2.1.0
-  test: ^1.25.12
-  mockito: ^5.4.4
+  test: ^1.25.14
+  mockito: ^5.4.5
   build_runner: any

--- a/packages/microsoft_kiota_http/pubspec.yaml
+++ b/packages/microsoft_kiota_http/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_http
 description: "Provides an implementation of a Kiota RequestAdapter that uses `http`."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_http
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/microsoft_kiota_http/pubspec.yaml
+++ b/packages/microsoft_kiota_http/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_http
 description: "Provides an implementation of a Kiota RequestAdapter that uses `http`."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_http
 repository: https://github.com/microsoft/dart_kiota
 
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  microsoft_kiota_abstractions: '>=0.0.1 <1.0.0'
+  microsoft_kiota_abstractions: ^0.0.1
   http: ^1.2.2
   http_parser: ^4.0.2
   uuid: ^4.5.1

--- a/packages/microsoft_kiota_http/pubspec.yaml
+++ b/packages/microsoft_kiota_http/pubspec.yaml
@@ -6,7 +6,9 @@ repository: https://github.com/kiota-community/dart_kiota
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   microsoft_kiota_abstractions:

--- a/packages/microsoft_kiota_serialization_form/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_form/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_serialization_form
 description: "Provides parsing and serialization support for the `application/x-www-form-urlencoded` content type."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_form
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/microsoft_kiota_serialization_form/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_form/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
 dev_dependencies:
   build_runner: any
   strict: ^2.1.0
-  test: ^1.25.12
-  mockito: ^5.4.4
+  test: ^1.25.14
+  mockito: ^5.4.5

--- a/packages/microsoft_kiota_serialization_form/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_form/pubspec.yaml
@@ -6,7 +6,9 @@ repository: https://github.com/kiota-community/dart_kiota
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   microsoft_kiota_abstractions:

--- a/packages/microsoft_kiota_serialization_form/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_serialization_form
 description: "Provides parsing and serialization support for the `application/x-www-form-urlencoded` content type."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_form
 repository: https://github.com/microsoft/dart_kiota
 
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  microsoft_kiota_abstractions: '>=0.0.1 <1.0.0'
+  microsoft_kiota_abstractions: ^0.0.1
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/microsoft_kiota_serialization_json/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_json/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_serialization_json
 description: "Provides parsing and serialization support for the `application/json` content type."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_json
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/microsoft_kiota_serialization_json/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_json/pubspec.yaml
@@ -16,4 +16,4 @@ dependencies:
 dev_dependencies:
   build_runner: any
   strict: ^2.1.0
-  test: ^1.25.12
+  test: ^1.25.14

--- a/packages/microsoft_kiota_serialization_json/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_json/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_serialization_json
 description: "Provides parsing and serialization support for the `application/json` content type."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_json
 repository: https://github.com/microsoft/dart_kiota
 
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  microsoft_kiota_abstractions: '>=0.0.1 <1.0.0'
+  microsoft_kiota_abstractions: ^0.0.1
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/microsoft_kiota_serialization_json/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_json/pubspec.yaml
@@ -6,7 +6,9 @@ homepage: https://github.com/ricardoboss/dart_kiota/tree/main/packages/microsoft
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 # Add regular dependencies here.
 dependencies:

--- a/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_serialization_multipart
 description: "Provides parsing and serialization support for the `multipart/form-data` content type."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_multipart
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
@@ -6,7 +6,9 @@ repository: https://github.com/kiota-community/dart_kiota
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   http: ^1.2.2

--- a/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
@@ -18,6 +18,6 @@ dependencies:
 dev_dependencies:
   build_runner: any
   microsoft_kiota_serialization_json: ^0.0.1
-  mockito: ^5.4.4
+  mockito: ^5.4.5
   strict: ^2.1.0
-  test: ^1.25.12
+  test: ^1.25.14

--- a/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_multipart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_serialization_multipart
 description: "Provides parsing and serialization support for the `multipart/form-data` content type."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_multipart
 repository: https://github.com/microsoft/dart_kiota
 
@@ -11,13 +11,13 @@ resolution: workspace
 
 dependencies:
   http: ^1.2.2
-  microsoft_kiota_abstractions: '>=0.0.1 <1.0.0'
+  microsoft_kiota_abstractions: ^0.0.1
   typed_data: ^1.4.0
   uuid: ^4.5.1
 
 dev_dependencies:
   build_runner: any
-  microsoft_kiota_serialization_json: '>=0.0.1 <1.0.0'
+  microsoft_kiota_serialization_json: ^0.0.1
   mockito: ^5.4.4
   strict: ^2.1.0
   test: ^1.25.12

--- a/packages/microsoft_kiota_serialization_text/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_text/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
 
 dev_dependencies:
   strict: ^2.1.0
-  test: ^1.25.12
+  test: ^1.25.14

--- a/packages/microsoft_kiota_serialization_text/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_text/pubspec.yaml
@@ -2,7 +2,7 @@ name: microsoft_kiota_serialization_text
 description: "Provides parsing and serialization support for the `text/plain` content type."
 version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_text
-repository: https://github.com/microsoft/dart_kiota
+repository: https://github.com/microsoft/kiota-dart
 
 environment:
   sdk: ^3.6.0

--- a/packages/microsoft_kiota_serialization_text/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_text/pubspec.yaml
@@ -1,6 +1,6 @@
 name: microsoft_kiota_serialization_text
 description: "Provides parsing and serialization support for the `text/plain` content type."
-version: 0.0.1-pre.1
+version: 0.0.1
 homepage: https://github.com/microsoft/kiota-dart/tree/main/packages/microsoft_kiota_serialization_text
 repository: https://github.com/microsoft/dart_kiota
 
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  microsoft_kiota_abstractions: '>=0.0.1 <1.0.0'
+  microsoft_kiota_abstractions: ^0.0.1
   uuid: ^4.5.1
 
 dev_dependencies:

--- a/packages/microsoft_kiota_serialization_text/pubspec.yaml
+++ b/packages/microsoft_kiota_serialization_text/pubspec.yaml
@@ -6,7 +6,9 @@ repository: https://github.com/kiota-community/dart_kiota
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.2.6 <4.0.0'
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   microsoft_kiota_abstractions:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,15 @@
+name: _
+publish_to: none
+
+environment:
+  sdk: ^3.6.0
+
+workspace:
+  - packages/microsoft_kiota_abstractions
+  - packages/microsoft_kiota_bundle
+  - packages/microsoft_kiota_http
+  - packages/microsoft_kiota_serialization_form
+  - packages/microsoft_kiota_serialization_json
+  - packages/microsoft_kiota_serialization_multipart
+  - packages/microsoft_kiota_serialization_text
+  - tooling

--- a/tooling/pubspec.yaml
+++ b/tooling/pubspec.yaml
@@ -3,7 +3,9 @@ description: A sample command-line application.
 version: 1.0.0
 
 environment:
-  sdk: ^3.4.3
+  sdk: ^3.6.0
+
+resolution: workspace
 
 dependencies:
   args: ^2.5.0

--- a/tooling/pubspec.yaml
+++ b/tooling/pubspec.yaml
@@ -14,4 +14,4 @@ dependencies:
 
 dev_dependencies:
   lints: ">=3.0.0 <6.0.0"
-  test: ^1.25.12
+  test: ^1.25.14


### PR DESCRIPTION
Fixes #59, fixes #54, fixes #56.

This enables us to set any version for all the packages while not impacting local development experience or CI.
The versions just need to satisfy the inter-package version constraints.